### PR TITLE
Using SIMD instructions in mapZoom

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
-CC      = g++
-CFLAGS  = -O3 -Wall -fwrapv
+CC      = gcc
+CFLAGS  = -O3 -Wall -fwrapv -march=native
 LDFLAGS = -lm -pthread
 
 .PHONY : all clean


### PR DESCRIPTION
By far the most commonly used layer function is mapZoom. Speeding it up therefore has a substantial effect on the rest of the program. Using SIMD I was able to speed it up from 1m46.660s to 0m56.581s just using SSE4_2 and 0m46.138s using AVX2 in a test going down to the second to last layer(the one preceding the VoronoiZoom). I myself was surprised by how effective this change was so while it is possible my amazing test results were not entirely accurate this most definitely made a dent.