### PR TITLE
Initialize regPosX and regPosZ to zero when not specified on the command line.

### DIFF
--- a/find_quadhuts.c
+++ b/find_quadhuts.c
@@ -20,8 +20,8 @@ int main(int argc, char *argv[])
     initBiomes();
 
     // Translate the positions to the desired regions.
-    int regPosX;
-    int regPosZ;
+    int regPosX = 0;
+    int regPosZ = 0;
 
     if(argc > 2)
     {
@@ -90,7 +90,7 @@ int main(int argc, char *argv[])
             printf("(%d,%d) ", qhpos[j].x, qhpos[j].z);
         }
         printf("\n");
-        //*/
+        */
 
         // This little magic code checks if there is a meaningful chance for
         // this seed base to generate swamps in the area.

--- a/finders.c
+++ b/finders.c
@@ -531,6 +531,10 @@ static void *baseQuadTempleSearchThread(void *data)
     sprintf(fnam, "%s.part%d", info.fnam, info.threadID);
 
     FILE *fp = fopen(fnam, "a+");
+    if (fp == NULL) {
+        fprintf(stderr, "Could not open \"%s\" for writing.\n", fnam);
+        exit(-1);
+    }
 
     seed = start;
 
@@ -617,6 +621,10 @@ void baseQuadTempleSearch(const char *fnam, const int threads, const int quality
     char fnamThread[256];
     char buffer[4097];
     FILE *fp = fopen(fnam, "w");
+    if (fp == NULL) {
+        fprintf(stderr, "Could not open \"%s\" for writing.\n", fnam);
+        exit(-1);
+    }
     FILE *fpart;
     int n;
 

--- a/finders.c
+++ b/finders.c
@@ -809,7 +809,7 @@ Pos getMansionPos(long seed, const long area80X, const long area80Z)
     pos.z += (seed >> 17) % 60;
 
     pos.x = area80X*80 + (pos.x >> 1);
-    pos.z = area80X*80 + (pos.z >> 1);
+    pos.z = area80Z*80 + (pos.z >> 1);
     pos.x = pos.x*16 + 8;
     pos.z = pos.z*16 + 8;
     return pos;

--- a/finders.c
+++ b/finders.c
@@ -660,6 +660,8 @@ void baseQuadTempleSearch(const char *fnam, const int threads, const int quality
 /* getBiomeAtPos
  * ----------------
  * Returns the biome for the specified block position.
+ * (Alternatives should be considered in performance critical code.)
+ * This function is not threadsafe.
  */
 int getBiomeAtPos(const LayerStack g, const Pos pos)
 {

--- a/finders.h
+++ b/finders.h
@@ -126,6 +126,7 @@ void baseQuadTempleSearch(const char *fnam, int threads, int quality);
  * ----------------
  * Returns the biome for the specified block position.
  * (Alternatives should be considered in performance critical code.)
+ * This function is not threadsafe.
  */
 int getBiomeAtPos(const LayerStack g, const Pos pos);
 

--- a/layers.c
+++ b/layers.c
@@ -861,6 +861,7 @@ void mapBiomeEdge(Layer *l, int * __restrict out, int areaX, int areaZ, int area
 }
 
 
+/* This function is not threadsafe. */
 void mapHills(Layer *l, int * __restrict out, int areaX, int areaZ, int areaWidth, int areaHeight)
 {
     int pX = areaX - 1;

--- a/layers.h
+++ b/layers.h
@@ -376,6 +376,7 @@ void mapDeepOcean(Layer *l, int * __restrict out, int x, int z, int w, int h);
 void mapBiome(Layer *l, int * __restrict out, int x, int z, int w, int h);
 void mapRiverInit(Layer *l, int * __restrict out, int x, int z, int w, int h);
 void mapBiomeEdge(Layer *l, int * __restrict out, int x, int z, int w, int h);
+/* This function is not threadsafe. */
 void mapHills(Layer *l, int * __restrict out, int x, int z, int w, int h);
 void mapRiver(Layer *l, int * __restrict out, int x, int z, int w, int h);
 void mapSmooth(Layer *l, int * __restrict out, int x, int z, int w, int h);


### PR DESCRIPTION
Fixes issue #5.