### PR TITLE
Adding ocean ruins and shipwrecks

### DIFF
--- a/find_quadhuts.c
+++ b/find_quadhuts.c
@@ -109,18 +109,10 @@ int main(int argc, char *argv[])
     {
         base = moveStructure(qhcandidates[i], regPosX, regPosZ);
 
-        qhpos[0] = getStructurePos(
-                featureSeed, FEATURE_REGION_SIZE, FEATURE_CHUNK_RANGE,
-                base, 0+regPosX, 0+regPosZ);
-        qhpos[1] = getStructurePos(
-                featureSeed, FEATURE_REGION_SIZE, FEATURE_CHUNK_RANGE,
-                base, 0+regPosX, 1+regPosZ);
-        qhpos[2] = getStructurePos(
-                featureSeed, FEATURE_REGION_SIZE, FEATURE_CHUNK_RANGE,
-                base, 1+regPosX, 0+regPosZ);
-        qhpos[3] = getStructurePos(
-                featureSeed, FEATURE_REGION_SIZE, FEATURE_CHUNK_RANGE,
-                base, 1+regPosX, 1+regPosZ);
+        qhpos[0] = getStructurePos(featureSeed, base, 0+regPosX, 0+regPosZ);
+        qhpos[1] = getStructurePos(featureSeed, base, 0+regPosX, 1+regPosZ);
+        qhpos[2] = getStructurePos(featureSeed, base, 1+regPosX, 0+regPosZ);
+        qhpos[3] = getStructurePos(featureSeed, base, 1+regPosX, 1+regPosZ);
 
         /*
         for(j = 0; j < 4; j++)

--- a/find_quadhuts.c
+++ b/find_quadhuts.c
@@ -57,7 +57,7 @@ int main(int argc, char *argv[])
 
     if(mcversion == 113)
     {
-        featureSeed = SWAMP_HUT_SEED;
+        featureSeed = SWAMP_HUT_CONFIG.seed;
         seedFileName = "./seeds/quadhutbases_1_13_Q1.txt";
         // setupGeneratorMC113() biome generation is slower and unnecessary.
         // We are only interested in the biomes on land, which haven't changed
@@ -68,7 +68,7 @@ int main(int argc, char *argv[])
     }
     else
     {
-        featureSeed = FEATURE_SEED;
+        featureSeed = FEATURE_CONFIG.seed;
         seedFileName = "./seeds/quadhutbases_1_7_Q1.txt";
         g = setupGeneratorMC17();
     }
@@ -109,10 +109,10 @@ int main(int argc, char *argv[])
     {
         base = moveStructure(qhcandidates[i], regPosX, regPosZ);
 
-        qhpos[0] = getStructurePos(featureSeed, base, 0+regPosX, 0+regPosZ);
-        qhpos[1] = getStructurePos(featureSeed, base, 0+regPosX, 1+regPosZ);
-        qhpos[2] = getStructurePos(featureSeed, base, 1+regPosX, 0+regPosZ);
-        qhpos[3] = getStructurePos(featureSeed, base, 1+regPosX, 1+regPosZ);
+        qhpos[0] = getStructurePos(SWAMP_HUT_CONFIG, base, 0+regPosX, 0+regPosZ);
+        qhpos[1] = getStructurePos(SWAMP_HUT_CONFIG, base, 0+regPosX, 1+regPosZ);
+        qhpos[2] = getStructurePos(SWAMP_HUT_CONFIG, base, 1+regPosX, 0+regPosZ);
+        qhpos[3] = getStructurePos(SWAMP_HUT_CONFIG, base, 1+regPosX, 1+regPosZ);
 
         /*
         for(j = 0; j < 4; j++)

--- a/find_quadhuts.c
+++ b/find_quadhuts.c
@@ -109,10 +109,18 @@ int main(int argc, char *argv[])
     {
         base = moveStructure(qhcandidates[i], regPosX, regPosZ);
 
-        qhpos[0] = getStructurePos(featureSeed, base, 0+regPosX, 0+regPosZ);
-        qhpos[1] = getStructurePos(featureSeed, base, 0+regPosX, 1+regPosZ);
-        qhpos[2] = getStructurePos(featureSeed, base, 1+regPosX, 0+regPosZ);
-        qhpos[3] = getStructurePos(featureSeed, base, 1+regPosX, 1+regPosZ);
+        qhpos[0] = getStructurePos(
+                featureSeed, FEATURE_REGION_SIZE, FEATURE_CHUNK_RANGE,
+                base, 0+regPosX, 0+regPosZ);
+        qhpos[1] = getStructurePos(
+                featureSeed, FEATURE_REGION_SIZE, FEATURE_CHUNK_RANGE,
+                base, 0+regPosX, 1+regPosZ);
+        qhpos[2] = getStructurePos(
+                featureSeed, FEATURE_REGION_SIZE, FEATURE_CHUNK_RANGE,
+                base, 1+regPosX, 0+regPosZ);
+        qhpos[3] = getStructurePos(
+                featureSeed, FEATURE_REGION_SIZE, FEATURE_CHUNK_RANGE,
+                base, 1+regPosX, 1+regPosZ);
 
         /*
         for(j = 0; j < 4; j++)

--- a/finders.c
+++ b/finders.c
@@ -690,35 +690,68 @@ int getBiomeAtPos(const LayerStack g, const Pos pos)
     return biomeID;
 }
 
+
+Pos getOceanRuinPos(int64_t seed, const int64_t regionX, const int64_t regionZ) {
+    Pos pos;
+
+    // set seed
+    seed = regionX*341873128712 + regionZ*132897987541 + seed + OCEAN_RUIN_SEED;
+    seed = (seed ^ 0x5DEECE66DLL);// & ((1LL << 48) - 1);
+
+    seed = (seed * 0x5DEECE66DLL + 0xBLL) & 0xffffffffffff;
+    // Java RNG treats powers of 2 as a special case.
+    pos.x = (8 * (seed >> 17)) >> 31;
+
+    seed = (seed * 0x5DEECE66DLL + 0xBLL) & 0xffffffffffff;
+    pos.z = (8 * (seed >> 17)) >> 31;
+
+    pos.x = regionX*256 + (pos.x << 4) + 8;
+    pos.z = regionZ*256 + (pos.z << 4) + 8;
+    return pos;
+}
+
+
+Pos getShipwreckPos(int64_t seed, const int64_t regionX, const int64_t regionZ) {
+    Pos pos;
+
+    // set seed
+    seed = regionX*341873128712 + regionZ*132897987541 + seed + SHIPWRECK_SEED;
+    seed = (seed ^ 0x5DEECE66DLL);// & ((1LL << 48) - 1);
+
+    seed = (seed * 0x5DEECE66DLL + 0xBLL) & 0xffffffffffff;
+    pos.x = (seed >> 17) % 7;
+
+    seed = (seed * 0x5DEECE66DLL + 0xBLL) & 0xffffffffffff;
+    pos.z = (seed >> 17) % 7;
+
+    pos.x = regionX*240 + (pos.x << 4) + 8;
+    pos.z = regionZ*240 + (pos.z << 4) + 8;
+    return pos;
+}
+
+
 /* getStructurePos
  * ---------------
  * Fast implementation for finding the block position at which the structure
  * generation attempt will occur in the specified region.
  * This function applies for scattered-feature structureSeeds and villages.
  */
-Pos getStructurePos(const int64_t structureSeed, const int regionSize, const int chunkRange,
-        int64_t seed, const int64_t regionX, const int64_t regionZ)
+Pos getStructurePos(const int64_t structureSeed, int64_t seed,
+        const int64_t regionX, const int64_t regionZ)
 {
     Pos pos;
 
-    // set seed
     seed = regionX*341873128712 + regionZ*132897987541 + seed + structureSeed;
     seed = (seed ^ 0x5DEECE66DLL);// & ((1LL << 48) - 1);
 
     seed = (seed * 0x5DEECE66DLL + 0xBLL) & 0xffffffffffff;
-    if ((chunkRange & (chunkRange-1)) == 0) {
-        // Java RNG treats powers of 2 as a special case.
-        pos.x = (chunkRange * (seed >> 17)) >> 31;
-        seed = (seed * 0x5DEECE66DLL + 0xBLL) & 0xffffffffffff;
-        pos.z = (chunkRange * (seed >> 17)) >> 31;
-    } else {
-        pos.x = (seed >> 17) % chunkRange;
-        seed = (seed * 0x5DEECE66DLL + 0xBLL) & 0xffffffffffff;
-        pos.z = (seed >> 17) % chunkRange;
-    }
+    pos.x = (seed >> 17) % 24;
 
-    pos.x = ((regionX*regionSize + pos.x) << 4) + 8;
-    pos.z = ((regionZ*regionSize + pos.z) << 4) + 8;
+    seed = (seed * 0x5DEECE66DLL + 0xBLL) & 0xffffffffffff;
+    pos.z = (seed >> 17) % 24;
+
+    pos.x = regionX*512 + (pos.x << 4) + 8;
+    pos.z = regionZ*512 + (pos.z << 4) + 8;
     return pos;
 }
 
@@ -729,8 +762,8 @@ Pos getStructurePos(const int64_t structureSeed, const int regionSize, const int
  * the structure generation attempt will occur.
  * This function applies for scattered-feature structureSeeds and villages.
  */
-Pos getStructureChunkInRegion(const int64_t structureSeed, const int chunkRange,
-        int64_t seed, const int regionX, const int regionZ)
+Pos getStructureChunkInRegion(const int64_t structureSeed, int64_t seed,
+        const int regionX, const int regionZ)
 {
     /*
     // Vanilla like implementation.
@@ -743,21 +776,14 @@ Pos getStructureChunkInRegion(const int64_t structureSeed, const int chunkRange,
     */
     Pos pos;
 
-    // set seed
     seed = regionX*341873128712 + regionZ*132897987541 + seed + structureSeed;
     seed = (seed ^ 0x5DEECE66DLL);// & ((1LL << 48) - 1);
 
     seed = (seed * 0x5DEECE66DLL + 0xBLL) & 0xffffffffffff;
-    if ((chunkRange & (chunkRange-1)) == 0) {
-        // Java RNG treats powers of 2 as a special case.
-        pos.x = (chunkRange * (seed >> 17)) >> 31;
-        seed = (seed * 0x5DEECE66DLL + 0xBLL) & 0xffffffffffff;
-        pos.z = (chunkRange * (seed >> 17)) >> 31;
-    } else {
-        pos.x = (seed >> 17) % chunkRange;
-        seed = (seed * 0x5DEECE66DLL + 0xBLL) & 0xffffffffffff;
-        pos.z = (seed >> 17) % chunkRange;
-    }
+    pos.x = (seed >> 17) % 24;
+
+    seed = (seed * 0x5DEECE66DLL + 0xBLL) & 0xffffffffffff;
+    pos.z = (seed >> 17) % 24;
 
     return pos;
 }

--- a/finders.c
+++ b/finders.c
@@ -11,6 +11,20 @@
 
 Biome biomes[256];
 
+/* For desert temples, igloos, jungle temples and witch huts prior to 1.13. */
+const StructureConfig FEATURE_CONFIG        = { 14357617, 32, 24};
+
+/* 1.13 separated feature seeds by type */
+const StructureConfig DESERT_PYRAMID_CONFIG = { 14357617, 32, 24};
+const StructureConfig IGLOO_CONFIG          = { 14357618, 32, 24};
+const StructureConfig JUNGLE_PYRAMID_CONFIG = { 14357619, 32, 24};
+const StructureConfig SWAMP_HUT_CONFIG      = { 14357620, 32, 24};
+
+const StructureConfig VILLAGE_CONFIG        = { 10387312, 32, 24};
+const StructureConfig OCEAN_RUIN_CONFIG     = { 14357621, 16,  8};
+const StructureConfig SHIPWRECK_CONFIG      = {165745295, 15,  7};
+const StructureConfig MONUMENT_CONFIG       = {165745295, 32, 27};
+const StructureConfig MANSION_CONFIG        = {165745295, 80, 60};
 
 
 /******************************** SEED FINDING *********************************
@@ -198,10 +212,10 @@ int64_t moveStructure(const int64_t baseSeed, const int regionX, const int regio
 int isQuadMonumentBase(const int64_t seed, const int qual)
 {
     // seed offsets for the regions (0,0) to (1,1)
-    const int64_t reg00base = MONUMENT_SEED;
-    const int64_t reg01base = 341873128712 + MONUMENT_SEED;
-    const int64_t reg10base = 132897987541 + MONUMENT_SEED;
-    const int64_t reg11base = 341873128712 + 132897987541 + MONUMENT_SEED;
+    const int64_t reg00base = MONUMENT_CONFIG.seed;
+    const int64_t reg01base = 341873128712 + MONUMENT_CONFIG.seed;
+    const int64_t reg10base = 132897987541 + MONUMENT_CONFIG.seed;
+    const int64_t reg11base = 341873128712 + 132897987541 + MONUMENT_CONFIG.seed;
 
     int64_t s, p;
 
@@ -283,10 +297,10 @@ int isQuadMonumentBase(const int64_t seed, const int qual)
 int isTriMonumentBase(const int64_t seed, const int qual)
 {
     // seed offsets for the regions (0,0) to (1,1)
-    const int64_t reg00base = MONUMENT_SEED;
-    const int64_t reg01base = 341873128712 + MONUMENT_SEED;
-    const int64_t reg10base = 132897987541 + MONUMENT_SEED;
-    const int64_t reg11base = 341873128712 + 132897987541 + MONUMENT_SEED;
+    const int64_t reg00base = MONUMENT_CONFIG.seed;
+    const int64_t reg01base = 341873128712 + MONUMENT_CONFIG.seed;
+    const int64_t reg10base = 132897987541 + MONUMENT_CONFIG.seed;
+    const int64_t reg11base = 341873128712 + 132897987541 + MONUMENT_CONFIG.seed;
 
     int64_t s, p;
     int incomplete = 0;
@@ -691,41 +705,27 @@ int getBiomeAtPos(const LayerStack g, const Pos pos)
 }
 
 
+/* getOceanRuinPos
+ * ---------------
+ * Fast implementation for finding the block position at which an ocean ruin
+ * generation attempt will occur in the specified region.
+ */
 Pos getOceanRuinPos(int64_t seed, const int64_t regionX, const int64_t regionZ) {
     Pos pos;
 
     // set seed
-    seed = regionX*341873128712 + regionZ*132897987541 + seed + OCEAN_RUIN_SEED;
+    seed = regionX*341873128712 + regionZ*132897987541 + seed + OCEAN_RUIN_CONFIG.seed;
     seed = (seed ^ 0x5DEECE66DLL);// & ((1LL << 48) - 1);
 
     seed = (seed * 0x5DEECE66DLL + 0xBLL) & 0xffffffffffff;
     // Java RNG treats powers of 2 as a special case.
-    pos.x = (8 * (seed >> 17)) >> 31;
+    pos.x = (OCEAN_RUIN_CONFIG.chunkRange * (seed >> 17)) >> 31;
 
     seed = (seed * 0x5DEECE66DLL + 0xBLL) & 0xffffffffffff;
-    pos.z = (8 * (seed >> 17)) >> 31;
+    pos.z = (OCEAN_RUIN_CONFIG.chunkRange * (seed >> 17)) >> 31;
 
-    pos.x = regionX*256 + (pos.x << 4) + 8;
-    pos.z = regionZ*256 + (pos.z << 4) + 8;
-    return pos;
-}
-
-
-Pos getShipwreckPos(int64_t seed, const int64_t regionX, const int64_t regionZ) {
-    Pos pos;
-
-    // set seed
-    seed = regionX*341873128712 + regionZ*132897987541 + seed + SHIPWRECK_SEED;
-    seed = (seed ^ 0x5DEECE66DLL);// & ((1LL << 48) - 1);
-
-    seed = (seed * 0x5DEECE66DLL + 0xBLL) & 0xffffffffffff;
-    pos.x = (seed >> 17) % 7;
-
-    seed = (seed * 0x5DEECE66DLL + 0xBLL) & 0xffffffffffff;
-    pos.z = (seed >> 17) % 7;
-
-    pos.x = regionX*240 + (pos.x << 4) + 8;
-    pos.z = regionZ*240 + (pos.z << 4) + 8;
+    pos.x = ((regionX*OCEAN_RUIN_CONFIG.regionSize + pos.x) << 4) + 8;
+    pos.z = ((regionZ*OCEAN_RUIN_CONFIG.regionSize + pos.z) << 4) + 8;
     return pos;
 }
 
@@ -734,35 +734,35 @@ Pos getShipwreckPos(int64_t seed, const int64_t regionX, const int64_t regionZ) 
  * ---------------
  * Fast implementation for finding the block position at which the structure
  * generation attempt will occur in the specified region.
- * This function applies for scattered-feature structureSeeds and villages.
+ * This function applies for scattered-feature structures and villages.
  */
-Pos getStructurePos(const int64_t structureSeed, int64_t seed,
+Pos getStructurePos(const StructureConfig config, int64_t seed,
         const int64_t regionX, const int64_t regionZ)
 {
     Pos pos;
 
-    seed = regionX*341873128712 + regionZ*132897987541 + seed + structureSeed;
+    seed = regionX*341873128712 + regionZ*132897987541 + seed + config.seed;
     seed = (seed ^ 0x5DEECE66DLL);// & ((1LL << 48) - 1);
 
     seed = (seed * 0x5DEECE66DLL + 0xBLL) & 0xffffffffffff;
-    pos.x = (seed >> 17) % 24;
+    pos.x = (seed >> 17) % config.chunkRange;
 
     seed = (seed * 0x5DEECE66DLL + 0xBLL) & 0xffffffffffff;
-    pos.z = (seed >> 17) % 24;
+    pos.z = (seed >> 17) % config.chunkRange;
 
-    pos.x = regionX*512 + (pos.x << 4) + 8;
-    pos.z = regionZ*512 + (pos.z << 4) + 8;
+    pos.x = ((regionX*config.regionSize + pos.x) << 4) + 8;
+    pos.z = ((regionZ*config.regionSize + pos.z) << 4) + 8;
     return pos;
 }
 
 
 /* getStructureChunkInRegion
  * -------------------------
- * Finds the chunk position within the specified region (32x32 chunks) where
- * the structure generation attempt will occur.
+ * Fast implementation for finding the chunk position at which the structure
+ * generation attempt will occur in the specified region.
  * This function applies for scattered-feature structureSeeds and villages.
  */
-Pos getStructureChunkInRegion(const int64_t structureSeed, int64_t seed,
+Pos getStructureChunkInRegion(const StructureConfig config, int64_t seed,
         const int regionX, const int regionZ)
 {
     /*
@@ -776,80 +776,81 @@ Pos getStructureChunkInRegion(const int64_t structureSeed, int64_t seed,
     */
     Pos pos;
 
-    seed = regionX*341873128712 + regionZ*132897987541 + seed + structureSeed;
+    seed = regionX*341873128712 + regionZ*132897987541 + seed + config.seed;
     seed = (seed ^ 0x5DEECE66DLL);// & ((1LL << 48) - 1);
 
     seed = (seed * 0x5DEECE66DLL + 0xBLL) & 0xffffffffffff;
-    pos.x = (seed >> 17) % 24;
+    pos.x = (seed >> 17) % config.chunkRange;
 
     seed = (seed * 0x5DEECE66DLL + 0xBLL) & 0xffffffffffff;
-    pos.z = (seed >> 17) % 24;
+    pos.z = (seed >> 17) % config.chunkRange;
 
     return pos;
 }
 
 
 
-/* getOceanMonumentPos
+/* getLargeStructurePos
  * -------------------
  * Fast implementation for finding the block position at which the ocean
- * monument generation attempt will occur in the specified region.
+ * monument or woodland mansion generation attempt will occur in the
+ * specified region.
  */
-Pos getOceanMonumentPos(int64_t seed, const int64_t regionX, const int64_t regionZ)
+Pos getLargeStructurePos(StructureConfig config, int64_t seed,
+        const int64_t regionX, const int64_t regionZ)
 {
     Pos pos;
 
     // set seed
-    seed = regionX*341873128712 + regionZ*132897987541 + seed + MONUMENT_SEED;
+    seed = regionX*341873128712 + regionZ*132897987541 + seed + config.seed;
     seed = (seed ^ 0x5DEECE66DLL) & ((1LL << 48) - 1);
 
     seed = (seed * 0x5DEECE66DLL + 0xBLL) & 0xffffffffffff;
-    pos.x = (seed >> 17) % 27;
+    pos.x = (seed >> 17) % config.chunkRange;
     seed = (seed * 0x5DEECE66DLL + 0xBLL) & 0xffffffffffff;
-    pos.x += (seed >> 17) % 27;
+    pos.x += (seed >> 17) % config.chunkRange;
 
     seed = (seed * 0x5DEECE66DLL + 0xBLL) & 0xffffffffffff;
-    pos.z = (seed >> 17) % 27;
+    pos.z = (seed >> 17) % config.chunkRange;
     seed = (seed * 0x5DEECE66DLL + 0xBLL) & 0xffffffffffff;
-    pos.z += (seed >> 17) % 27;
+    pos.z += (seed >> 17) % config.chunkRange;
 
-    pos.x = regionX*32 + (pos.x >> 1);
-    pos.z = regionZ*32 + (pos.z >> 1);
+    pos.x = regionX*config.regionSize + (pos.x >> 1);
+    pos.z = regionZ*config.regionSize + (pos.z >> 1);
     pos.x = pos.x*16 + 8;
     pos.z = pos.z*16 + 8;
     return pos;
 }
 
 
-/* getMansionPos
- * -------------
- * Fast implementation for finding the block position at which the woodland
- * mansions generation attempt will occur in the specified 80x80 chunk area.
- *
- * area80X, area80Z: area coordinates in units 1280 blocks (= 80 chunks)
+/* getLargeStructureChunkInRegion
+ * -------------------
+ * Fast implementation for finding the Chunk position at which the ocean
+ * monument or woodland mansion generation attempt will occur in the
+ * specified region.
  */
-Pos getMansionPos(int64_t seed, const int64_t area80X, const int64_t area80Z)
+Pos getLargeStructureChunkInRegion(StructureConfig config, int64_t seed,
+        const int64_t regionX, const int64_t regionZ)
 {
     Pos pos;
 
     // set seed
-    seed = area80X*341873128712 + area80Z*132897987541 + seed + MANSION_SEED;
-    seed = (seed ^ 0x5DEECE66DLL);// & ((1LL << 48) - 1);
+    seed = regionX*341873128712 + regionZ*132897987541 + seed + config.seed;
+    seed = (seed ^ 0x5DEECE66DLL) & ((1LL << 48) - 1);
 
     seed = (seed * 0x5DEECE66DLL + 0xBLL) & 0xffffffffffff;
-    pos.x = (seed >> 17) % 60;
+    pos.x = (seed >> 17) % config.chunkRange;
     seed = (seed * 0x5DEECE66DLL + 0xBLL) & 0xffffffffffff;
-    pos.x += (seed >> 17) % 60;
+    pos.x += (seed >> 17) % config.chunkRange;
 
     seed = (seed * 0x5DEECE66DLL + 0xBLL) & 0xffffffffffff;
-    pos.z = (seed >> 17) % 60;
+    pos.z = (seed >> 17) % config.chunkRange;
     seed = (seed * 0x5DEECE66DLL + 0xBLL) & 0xffffffffffff;
-    pos.z += (seed >> 17) % 60;
+    pos.z += (seed >> 17) % config.chunkRange;
 
-    pos.x = area80X*80 + (pos.x >> 1);
-    pos.z = area80Z*80 + (pos.z >> 1);
-    pos.x = pos.x*16 + 8;
-    pos.z = pos.z*16 + 8;
+    pos.x >>= 1;
+    pos.z >>= 1;
+
     return pos;
 }
 

--- a/finders.c
+++ b/finders.c
@@ -23,8 +23,8 @@ const StructureConfig SWAMP_HUT_CONFIG      = { 14357620, 32, 24};
 const StructureConfig VILLAGE_CONFIG        = { 10387312, 32, 24};
 const StructureConfig OCEAN_RUIN_CONFIG     = { 14357621, 16,  8};
 const StructureConfig SHIPWRECK_CONFIG      = {165745295, 15,  7};
-const StructureConfig MONUMENT_CONFIG       = {165745295, 32, 27};
-const StructureConfig MANSION_CONFIG        = {165745295, 80, 60};
+const StructureConfig MONUMENT_CONFIG       = { 10387313, 32, 27};
+const StructureConfig MANSION_CONFIG        = { 10387319, 80, 60};
 
 
 /******************************** SEED FINDING *********************************
@@ -787,7 +787,6 @@ Pos getStructureChunkInRegion(const StructureConfig config, int64_t seed,
 
     return pos;
 }
-
 
 
 /* getLargeStructurePos

--- a/finders.h
+++ b/finders.h
@@ -12,32 +12,25 @@
 #define SEEDMAX (1LL << 48)
 #define PI 3.141592653589793
 
-#define FEATURE_SEED        14357617
-#define VILLAGE_SEED        10387312
-#define MONUMENT_SEED       10387313
-#define MANSION_SEED        10387319
+STRUCT(StructureConfig) {
+    int64_t seed;
+    int regionSize, chunkRange;
+};
+
+/* For desert temples, igloos, jungle temples and witch huts prior to 1.13. */
+extern const StructureConfig FEATURE_CONFIG;
 
 /* 1.13 separated feature seeds by type */
-#define DESERT_PYRAMID_SEED 14357617
-#define IGLOO_SEED          14357618
-#define JUNGLE_PYRAMID_SEED 14357619
-#define SWAMP_HUT_SEED      14357620
-#define OCEAN_RUIN_SEED     14357621
-#define SHIPWRECK_SEED     165745295
+extern const StructureConfig DESERT_PYRAMID_CONFIG;
+extern const StructureConfig IGLOO_CONFIG;
+extern const StructureConfig JUNGLE_PYRAMID_CONFIG;
+extern const StructureConfig SWAMP_HUT_CONFIG;
 
-#define FEATURE_CHUNK_RANGE       24
-#define VILLAGE_CHUNK_RANGE       24
-#define MONUMENT_CHUNK_RANGE      27
-#define MANSION_CHUNK_RANGE       60
-#define OCEAN_RUIN_CHUNK_RANGE     8
-#define SHIPWRECK_CHUNK_RANGE      7
-
-#define FEATURE_REGION_SIZE       32
-#define VILLAGE_REGION_SIZE       32
-#define MONUMENT_REGION_SIZE      32
-#define MANSION_REGION_SIZE       80
-#define OCEAN_RUIN_REGION_SIZE    16
-#define SHIPWRECK_REGION_SIZE     15
+extern const StructureConfig VILLAGE_CONFIG;
+extern const StructureConfig OCEAN_RUIN_CONFIG;
+extern const StructureConfig SHIPWRECK_CONFIG;
+extern const StructureConfig MONUMENT_CONFIG;
+extern const StructureConfig MANSION_CONFIG;
 
 enum {Desert_Pyramid=1, Igloo, Jungle_Pyramid, Swamp_Hut, Ocean_Ruin};
 
@@ -169,20 +162,13 @@ int getBiomeAtPos(const LayerStack g, const Pos pos);
  */
 Pos getOceanRuinPos(int64_t seed, const int64_t regionX, const int64_t regionZ);
 
-/* getShipwreckPos
- * ---------------
- * Fast implementation for finding the block position at which a shipwreck
- * generation attempt will occur in the specified region.
- */
-Pos getShipwreckPos(int64_t seed, const int64_t regionX, const int64_t regionZ);
-
 /* getStructurePos
  * ---------------
  * Fast implementation for finding the block position at which the structure
  * generation attempt will occur in the specified region.
  * This function applies for scattered-feature structureSeeds and villages.
  */
-Pos getStructurePos(const int64_t structureSeed, int64_t seed,
+Pos getStructurePos(StructureConfig config, int64_t seed,
         const int64_t regionX, const int64_t regionZ);
 
 /* getStructureChunkInRegion
@@ -193,24 +179,26 @@ Pos getStructurePos(const int64_t structureSeed, int64_t seed,
  *
  * This function applies for scattered-feature structureSeeds and villages.
  */
-Pos getStructureChunkInRegion(const int64_t structureSeed, int64_t seed,
+Pos getStructureChunkInRegion(StructureConfig config, int64_t seed,
         const int regionX, const int regionZ);
 
-/* getOceanMonumentPos
+/* getLargeStructurePos
  * -------------------
  * Fast implementation for finding the block position at which the ocean
- * monument generation attempt will occur in the specified region.
+ * monument or woodland mansion generation attempt will occur in the
+ * specified region.
  */
-Pos getOceanMonumentPos(int64_t seed, const int64_t regionX, const int64_t regionZ);
+Pos getLargeStructurePos(StructureConfig config, int64_t seed,
+        const int64_t regionX, const int64_t regionZ);
 
-/* getMansionPos
- * -------------
- * Fast implementation for finding the block position at which the woodland
- * mansions generation attempt will occur in the specified 80x80 chunk area.
- *
- * area80X, area80Z: area coordinates in units 1280 blocks (= 80 chunks)
+/* getLargeStructureChunkInRegion
+ * -------------------
+ * Fast implementation for finding the chunk position at which the ocean
+ * monument or woodland mansion generation attempt will occur in the
+ * specified region.
  */
-Pos getMansionPos(int64_t seed, const int64_t area80X, const int64_t area80Z);
+Pos getLargeStructureChunkInRegion(StructureConfig config, int64_t seed,
+        const int64_t regionX, const int64_t regionZ);
 
 
 /* findBiomePosition

--- a/finders.h
+++ b/finders.h
@@ -162,6 +162,29 @@ void search4QuadBases(const char *fnam, int threads, const int64_t structureSeed
 int getBiomeAtPos(const LayerStack g, const Pos pos);
 
 
+/* getOceanRuinPos
+ * ---------------
+ * Fast implementation for finding the block position at which an ocean ruin
+ * generation attempt will occur in the specified region.
+ */
+Pos getOceanRuinPos(int64_t seed, const int64_t regionX, const int64_t regionZ);
+
+/* getShipwreckPos
+ * ---------------
+ * Fast implementation for finding the block position at which a shipwreck
+ * generation attempt will occur in the specified region.
+ */
+Pos getShipwreckPos(int64_t seed, const int64_t regionX, const int64_t regionZ);
+
+/* getStructurePos
+ * ---------------
+ * Fast implementation for finding the block position at which the structure
+ * generation attempt will occur in the specified region.
+ * This function applies for scattered-feature structureSeeds and villages.
+ */
+Pos getStructurePos(const int64_t structureSeed, int64_t seed,
+        const int64_t regionX, const int64_t regionZ);
+
 /* getStructureChunkInRegion
  * -------------------------
  * Finds the chunk position within the specified region (a square region of
@@ -170,19 +193,8 @@ int getBiomeAtPos(const LayerStack g, const Pos pos);
  *
  * This function applies for scattered-feature structureSeeds and villages.
  */
-Pos getStructureChunkInRegion(const int64_t structureSeed, const int chunkRange,
-        int64_t seed, const int regionX, const int regionZ);
-
-
-/* getStructurePos
- * ---------------
- * Fast implementation for finding the block position at which the structure
- * generation attempt will occur in the specified region.
- * This function applies for scattered-feature structureSeeds and villages.
- */
-Pos getStructurePos(const int64_t structureSeed, const int chunkRange,
-        const int regionSize, int64_t seed, const int64_t regionX, const int64_t regionZ);
-
+Pos getStructureChunkInRegion(const int64_t structureSeed, int64_t seed,
+        const int regionX, const int regionZ);
 
 /* getOceanMonumentPos
  * -------------------

--- a/finders.h
+++ b/finders.h
@@ -23,6 +23,21 @@
 #define JUNGLE_PYRAMID_SEED 14357619
 #define SWAMP_HUT_SEED      14357620
 #define OCEAN_RUIN_SEED     14357621
+#define SHIPWRECK_SEED     165745295
+
+#define FEATURE_CHUNK_RANGE       24
+#define VILLAGE_CHUNK_RANGE       24
+#define MONUMENT_CHUNK_RANGE      27
+#define MANSION_CHUNK_RANGE       60
+#define OCEAN_RUIN_CHUNK_RANGE     8
+#define SHIPWRECK_CHUNK_RANGE      7
+
+#define FEATURE_REGION_SIZE       32
+#define VILLAGE_REGION_SIZE       32
+#define MONUMENT_REGION_SIZE      32
+#define MANSION_REGION_SIZE       80
+#define OCEAN_RUIN_REGION_SIZE    16
+#define SHIPWRECK_REGION_SIZE     15
 
 enum {Desert_Pyramid=1, Igloo, Jungle_Pyramid, Swamp_Hut, Ocean_Ruin};
 
@@ -149,12 +164,14 @@ int getBiomeAtPos(const LayerStack g, const Pos pos);
 
 /* getStructureChunkInRegion
  * -------------------------
- * Finds the chunk position within the specified region (32x32 chunks) where
- * the structure generation attempt will occur.
+ * Finds the chunk position within the specified region (a square region of
+ * chunks depending on structure type) where the structure generation attempt
+ * will occur.
+ *
  * This function applies for scattered-feature structureSeeds and villages.
  */
-Pos getStructureChunkInRegion(const int64_t structureSeed, int64_t seed,
-        const int regionX, const int regionZ);
+Pos getStructureChunkInRegion(const int64_t structureSeed, const int chunkRange,
+        int64_t seed, const int regionX, const int regionZ);
 
 
 /* getStructurePos
@@ -163,8 +180,8 @@ Pos getStructureChunkInRegion(const int64_t structureSeed, int64_t seed,
  * generation attempt will occur in the specified region.
  * This function applies for scattered-feature structureSeeds and villages.
  */
-Pos getStructurePos(const int64_t structureSeed, int64_t seed, const int64_t regionX,
-        const int64_t regionZ);
+Pos getStructurePos(const int64_t structureSeed, const int chunkRange,
+        const int regionSize, int64_t seed, const int64_t regionX, const int64_t regionZ);
 
 
 /* getOceanMonumentPos

--- a/layers.c
+++ b/layers.c
@@ -1084,7 +1084,7 @@ void mapRareBiome(Layer *l, int * __restrict out, int areaX, int areaZ, int area
 
             if(mcNextInt(l, 57) == 0 && v11 == plains)
             {
-                // Flower Forest
+                // Sunflower Plains
                 out[x + z*areaWidth] = plains + 128;
             }
             else


### PR DESCRIPTION
Also refactors the structure code to have configurations for each structure type.

It keeps ocean ruins as a separate function since it triggers a special case in the Java RNG, and I'd rather not add the branch for all the other structure types.