### PR TITLE
Fix biomeExists when called with id > 0xff

### DIFF
--- a/layers.h
+++ b/layers.h
@@ -107,7 +107,7 @@ static inline int getBiomeType(int id)
 
 static inline int biomeExists(int id)
 {
-    return !(biomes[id & 0xff].id & (~0xff));
+    return id <= 0xff && !(biomes[id].id & (~0xff));
 }
 
 static inline int getTempCategory(int id)


### PR DESCRIPTION
Fix #23 

In mapHills, biomeExists is used to check for mutated biome variants.

If the biomeId passed to biomeExists is greater than 255, it just gets wrapped to a number below 255 by `id & 0xff`.

All the mutated biome variants have id = normalId + 128, so this only works if normalId is < 128. Recent updates have added the bambooJungleHills biome, which has id 169, so biomeExists(169 + 128) returns true because biome id 41 exists, when it should return false, because mutatedBambooJungleHills doesn't exists.

The fix is to always return false when biomeId > 255.