### PR TITLE
Fix biome checks for Jungle_Pyramid, Shipwreck, and Outpost

### DIFF
--- a/finders.c
+++ b/finders.c
@@ -1408,6 +1408,8 @@ int isViableFeaturePos(const int structureType, const LayerStack g, int *cache,
         return isOceanic(biomeID);
     case Shipwreck:
         return isOceanic(biomeID) || biomeID == beach || biomeID == snowy_beach;
+    case Ruined_Portal:
+        return 1;
     case Outpost:
         return biomeID == plains || biomeID == desert || biomeID == taiga || biomeID == snowy_tundra || biomeID == savanna;
     default:

--- a/finders.c
+++ b/finders.c
@@ -1401,14 +1401,15 @@ int isViableFeaturePos(const int structureType, const LayerStack g, int *cache,
     case Igloo:
         return biomeID == snowy_tundra || biomeID == snowy_taiga;
     case Jungle_Pyramid:
-        return biomeID == jungle || biomeID == jungle_hills;
+        return biomeID == jungle || biomeID == jungle_hills || biomeID == bamboo_jungle || biomeID == bamboo_jungle_hills;
     case Swamp_Hut:
         return biomeID == swamp;
     case Ocean_Ruin:
-    case Shipwreck:
         return isOceanic(biomeID);
-    case Ruined_Portal:
-        return 1;
+    case Shipwreck:
+        return isOceanic(biomeID) || biomeID == beach || biomeID == snowy_beach;
+    case Outpost:
+        return biomeID == plains || biomeID == desert || biomeID == taiga || biomeID == snowy_tundra || biomeID == savanna;
     default:
         fprintf(stderr, "Structure type is not valid for the scattered feature biome check.\n");
         exit(1);


### PR DESCRIPTION
Fixed biome checks in `isViableFeaturePos` function for `Jungle_Pyramid` and `Shipwreck`.

`Shipwreck`: shipwreck can spawn on "beach" and "snowy_beach".
`Jungle_Pyramid`: jungle pyramid can spawn on "bamboo_jungle" and "bamboo_jungle_hills"

Also added biome check for `Outpost`.

Here is a sample program to check them.

```c
#include "finders.h"
#include "generator.h"
#include "layers.h"
#include <stdio.h>

int main() {
    initBiomes();
    LayerStack g = setupGenerator(MC_1_15);
    applySeed(&g, 12345678);

    // shipwreck on "snowy_beach"
    int shipwreck = isViableFeaturePos(Shipwreck, g, NULL, 4164, 2408); // should be 1
    printf("shipwreck: %d\n", shipwreck);

    int outpost = isViableFeaturePos(Outpost, g, NULL, -873, 1176); // should be 1
    printf("outpost: %d\n", outpost);

    // jungle_pyramid on "bamboo_jungle"
    int jungle_pyramid = isViableFeaturePos(Jungle_Pyramid, g, NULL, -9066, -8457); // should be 1
    printf("jungle_pyramid: %d\n", jungle_pyramid);
}
```