### PR TITLE
fix: correct write count in savePPM

### DIFF
--- a/util.c
+++ b/util.c
@@ -470,9 +470,10 @@ int savePPM(const char *path, const unsigned char *pixels, const unsigned int sx
     if (!fp)
         return -1;
     fprintf(fp, "P6\n%d %d\n255\n", sx, sy);
-    int written = fwrite(pixels, sx*sy, 3, fp);
+    size_t pixelsLen = 3 * sx * sy;
+    size_t written = fwrite(pixels, sizeof pixels[0], pixelsLen, fp);
     fclose(fp);
-    return (unsigned int)written != 3*sx*sy;
+    return written != pixelsLen;
 }
 
 

--- a/util.h
+++ b/util.h
@@ -29,6 +29,9 @@ int biomesToImage(unsigned char *pixels,
         const unsigned int sx, const unsigned int sy,
         const unsigned int pixscale, const int flip);
 
+/// Save the pixel buffer (e.g. from biomesToImage) to the given path in PPM format.
+/// Returns 0 if successful, or -1 if the file could not be opened,
+/// or 1 if not all the pixel data could be written to the file.
 int savePPM(const char* path, const unsigned char *pixels,
         const unsigned int sx, const unsigned int sy);
 


### PR DESCRIPTION
Previously, the `fwrite` call always returned 3 if it succeeded, and so `savePPM` would return 1 even if the entire pixel buffer was successfully written to file (except in the trivial case `sx * sy == 1`). This changes `savePPM` to return 0 if it was successful.

(I'm assuming that `savePPM` is intended to return 0 if successful, and non-zero otherwise. Please feel free to close this PR if my assumption is wrong.)