### PR TITLE
fix: compute bastion variants correctly for 1.16.1

### DIFF
--- a/finders.c
+++ b/finders.c
@@ -2404,8 +2404,8 @@ int getVariant(StructureVariant *r, int structType, int mc, uint64_t seed,
         break;
 
     case Bastion:
-        r->variant = nextInt(&rng, 4);
         r->rotation = nextInt(&rng, 4);
+        r->variant = nextInt(&rng, 4);
         // these are swapped in 1.16.1 only
         if (mc == MC_1_16_1) {
             uint8_t tmp;

--- a/finders.c
+++ b/finders.c
@@ -2404,8 +2404,15 @@ int getVariant(StructureVariant *r, int structType, int mc, uint64_t seed,
         break;
 
     case Bastion:
-        r->rotation = nextInt(&rng, 4);
         r->variant = nextInt(&rng, 4);
+        r->rotation = nextInt(&rng, 4);
+        // these are swapped in 1.16.1 only
+        if (mc == MC_1_16_1) {
+            uint8_t tmp;
+            tmp = r->variant;
+            r->variant = r->rotation;
+            r->rotation = tmp;
+        }
         switch (r->variant)
         {
         case 0: sx = 46; sy = 24; sz = 46; break; // units/air_base

--- a/layers.h
+++ b/layers.h
@@ -13,8 +13,8 @@ enum MCVersion
     MC_1_0, // <=1.0 Experimental!
     MC_1_1,  MC_1_2,  MC_1_3,  MC_1_4,  MC_1_5,  MC_1_6,
     MC_1_7,  MC_1_8,  MC_1_9,  MC_1_10, MC_1_11, MC_1_12,
-    MC_1_13, MC_1_14, MC_1_15, MC_1_16, MC_1_17, MC_1_18,
-    MC_1_19, MC_NEWEST = MC_1_19,
+    MC_1_13, MC_1_14, MC_1_15, MC_1_16, MC_1_16_1, MC_1_17,
+    MC_1_18, MC_1_19, MC_NEWEST = MC_1_19,
 };
 
 enum BiomeID

--- a/util.c
+++ b/util.c
@@ -10,26 +10,27 @@ const char* mc2str(int mc)
 {
     switch (mc)
     {
-    case MC_1_0:  return "1.0"; break;
-    case MC_1_1:  return "1.1"; break;
-    case MC_1_2:  return "1.2"; break;
-    case MC_1_3:  return "1.3"; break;
-    case MC_1_4:  return "1.4"; break;
-    case MC_1_5:  return "1.5"; break;
-    case MC_1_6:  return "1.6"; break;
-    case MC_1_7:  return "1.7"; break;
-    case MC_1_8:  return "1.8"; break;
-    case MC_1_9:  return "1.9"; break;
-    case MC_1_10: return "1.10"; break;
-    case MC_1_11: return "1.11"; break;
-    case MC_1_12: return "1.12"; break;
-    case MC_1_13: return "1.13"; break;
-    case MC_1_14: return "1.14"; break;
-    case MC_1_15: return "1.15"; break;
-    case MC_1_16: return "1.16"; break;
-    case MC_1_17: return "1.17"; break;
-    case MC_1_18: return "1.18"; break;
-    case MC_1_19: return "1.19"; break;
+    case MC_1_0:    return "1.0"; break;
+    case MC_1_1:    return "1.1"; break;
+    case MC_1_2:    return "1.2"; break;
+    case MC_1_3:    return "1.3"; break;
+    case MC_1_4:    return "1.4"; break;
+    case MC_1_5:    return "1.5"; break;
+    case MC_1_6:    return "1.6"; break;
+    case MC_1_7:    return "1.7"; break;
+    case MC_1_8:    return "1.8"; break;
+    case MC_1_9:    return "1.9"; break;
+    case MC_1_10:   return "1.10"; break;
+    case MC_1_11:   return "1.11"; break;
+    case MC_1_12:   return "1.12"; break;
+    case MC_1_13:   return "1.13"; break;
+    case MC_1_14:   return "1.14"; break;
+    case MC_1_15:   return "1.15"; break;
+    case MC_1_16:   return "1.16"; break;
+    case MC_1_16_1: return "1.16.1"; break;
+    case MC_1_17:   return "1.17"; break;
+    case MC_1_18:   return "1.18"; break;
+    case MC_1_19:   return "1.19"; break;
     default: return NULL;
     }
 }
@@ -39,6 +40,7 @@ int str2mc(const char *s)
     if (!strcmp(s, "1.19")) return MC_1_19;
     if (!strcmp(s, "1.18")) return MC_1_18;
     if (!strcmp(s, "1.17")) return MC_1_17;
+    if (!strcmp(s, "1.16.1")) return MC_1_16_1;
     if (!strcmp(s, "1.16")) return MC_1_16;
     if (!strcmp(s, "1.15")) return MC_1_15;
     if (!strcmp(s, "1.14")) return MC_1_14;


### PR DESCRIPTION
In Minecraft 1.16.1, a bastion's variant is sampled from its ChunkRandom before its rotation is sampled, not the other way around (as is so for 1.16.2 and above). I tested this on 10 or so bastions in 1.16.1 versus 1.16.2, and this PR fixes the computed bastion variants for 1.16.1.