### PR TITLE
>MC_1_13 getSpawn() can be simplified to remove the 1024x iteration.

### DIFF
--- a/finders.c
+++ b/finders.c
@@ -854,29 +854,12 @@ Pos getSpawn(const Generator *g)
 
     if (g->mc >= MC_1_13)
     {
-        int j, k, u, v;
-        j = k = u = v = 0;
-        for (i = 0; i < 1024; i++)
-        {
-            if (j > -16 && j <= 16 && k > -16 && k <= 16)
-            {
-                if (findServerSpawn(g, (spawn.x>>4)+j, (spawn.z>>4)+k,
+        if (findServerSpawn(g, spawn.x>>4, spawn.z>>4,
                     &bx, &bz, &bn, &accum))
-                {
-                    spawn.x = (int) round(bx / bn);
-                    spawn.z = (int) round(bz / bn);
-                    return spawn;
-                }
-            }
-
-            if (j == k || (j < 0 && j == -k) || (j > 0 && j == 1 - k))
-            {
-                int tmp = u;
-                u = -v;
-                v = tmp;
-            }
-            j += u;
-            k += v;
+        {
+           spawn.x = bx;
+           spawn.z = bz;
+           return spawn;
         }
     }
     else


### PR DESCRIPTION
Currently the code is set up to call findServerSpawn() 1024 times, each with a slightly different value of j and k. However, j and k start out as 0, and after each iteration they have u and v added to them... which are also 0, meaning the exact same call is made each time (and the sign-swapping does nothing to change that since -0 = 0). Thus, in its current form, the 1024x iteration loop can be removed entirely, speeding up any relevant programs by... well, 1024 times.