### PR TITLE
Support Beta 1.8 (Closes #67)

### DIFF
--- a/finders.c
+++ b/finders.c
@@ -150,7 +150,7 @@ int getStructureConfig(int structureType, int mc, StructureConfig *sconf)
         return 1;
     case Fortress:
         *sconf = mc <= MC_1_15 ? s_fortress_115 : s_fortress;
-        return 1;
+        return mc >= MC_1_0;
     case Bastion:
         *sconf = s_bastion;
         return mc >= MC_1_16;

--- a/generator.c
+++ b/generator.c
@@ -272,14 +272,31 @@ void setupLayerStack(LayerStack *g, int mc, int largeBiomes)
     // P1: parent 1
     // P2: parent 2
 
-    //             L                       M               V   Z  E  S     P1 P2
-    p = setupLayer(l+L_CONTINENT_4096,     mapContinent,   mc, 1, 0, 1,    0, 0);
-    p = setupLayer(l+L_ZOOM_2048,          mapZoomFuzzy,   mc, 2, 3, 2000, p, 0);
-    p = setupLayer(l+L_LAND_2048,          mapLand,        mc, 1, 2, 1,    p, 0);
-    p = setupLayer(l+L_ZOOM_1024,          mapZoom,        mc, 2, 3, 2001, p, 0);
-    p = setupLayer(l+L_LAND_1024_A,        mapLand,        mc, 1, 2, 2,    p, 0);
+    if (mc == MC_B1_8)
+    {   //             L                   M               V   Z  E  S     P1 P2
+        // NOTE: reusing slot for continent:4096, but scale is 1:8192
+        p = setupLayer(l+L_CONTINENT_4096, mapContinent,   mc, 1, 0, 1,    0, 0);
+        p = setupLayer(l+L_ZOOM_4096,      mapZoomFuzzy,   mc, 2, 3, 2000, p, 0);
+        p = setupLayer(l+L_LAND_4096,      mapLandB18,     mc, 1, 2, 1,    p, 0);
+        p = setupLayer(l+L_ZOOM_2048,      mapZoom,        mc, 2, 3, 2001, p, 0);
+        p = setupLayer(l+L_LAND_2048,      mapLandB18,     mc, 1, 2, 2,    p, 0);
+        p = setupLayer(l+L_ZOOM_1024,      mapZoom,        mc, 2, 3, 2002, p, 0);
+        p = setupLayer(l+L_LAND_1024_A,    mapLandB18,     mc, 1, 2, 3,    p, 0);
+        p = setupLayer(l+L_ZOOM_512,       mapZoom,        mc, 2, 3, 2003, p, 0);
+	p = setupLayer(l+L_LAND_512,       mapLandB18,     mc, 1, 2, 3,    p, 0);
+        p = setupLayer(l+L_ZOOM_256,       mapZoom,        mc, 2, 3, 2004, p, 0);
+	p = setupLayer(l+L_LAND_256,       mapLandB18,     mc, 1, 2, 3,    p, 0);
+    }
+    else
+    {   //             L                   M               V   Z  E  S     P1 P2
+        p = setupLayer(l+L_CONTINENT_4096, mapContinent,   mc, 1, 0, 1,    0, 0);
+        p = setupLayer(l+L_ZOOM_2048,      mapZoomFuzzy,   mc, 2, 3, 2000, p, 0);
+        p = setupLayer(l+L_LAND_2048,      mapLand,        mc, 1, 2, 1,    p, 0);
+        p = setupLayer(l+L_ZOOM_1024,      mapZoom,        mc, 2, 3, 2001, p, 0);
+        p = setupLayer(l+L_LAND_1024_A,    mapLand,        mc, 1, 2, 2,    p, 0);
+    }
 
-    if (mc <= MC_1_6)
+    if (mc > MC_B1_8 && mc <= MC_1_6)
     {   //             L                   M               V   Z  E  S     P1 P2
         p = setupLayer(l+L_SNOW_1024,      mapSnow16,      mc, 1, 2, 2,    p, 0);
         p = setupLayer(l+L_ZOOM_512,       mapZoom,        mc, 2, 3, 2002, p, 0);
@@ -287,12 +304,16 @@ void setupLayerStack(LayerStack *g, int mc, int largeBiomes)
         p = setupLayer(l+L_ZOOM_256,       mapZoom,        mc, 2, 3, 2003, p, 0);
         p = setupLayer(l+L_LAND_256,       mapLand16,      mc, 1, 2, 4,    p, 0);
         p = setupLayer(l+L_MUSHROOM_256,   mapMushroom,    mc, 1, 2, 5,    p, 0);
+    }
+
+    if (mc <= MC_1_6)
+    {
         p = setupLayer(l+L_BIOME_256,      mapBiome,       mc, 1, 0, 200,  p, 0);
         p = setupLayer(l+L_ZOOM_128,       mapZoom,        mc, 2, 3, 1000, p, 0);
         p = setupLayer(l+L_ZOOM_64,        mapZoom,        mc, 2, 3, 1001, p, 0);
         // river noise layer chain, also used to determine where hills generate
         p = setupLayer(l+L_NOISE_256,      mapNoise,       mc, 1, 0, 100,
-                       l+L_MUSHROOM_256, 0);
+                       (mc > MC_B1_8) ? l+L_MUSHROOM_256 : l+L_LAND_256, 0);
     }
     else
     {   //             L                   M               V   Z  E  S     P1 P2
@@ -335,7 +356,9 @@ void setupLayerStack(LayerStack *g, int mc, int largeBiomes)
     {   //             L                   M               V   Z  E  S     P1 P2
         p = setupLayer(l+L_ZOOM_32,        mapZoom,        mc, 2, 3, 1000,
                        l+L_ZOOM_64, 0);
-        p = setupLayer(l+L_LAND_32,        mapLand16,      mc, 1, 2, 3,    p, 0);
+        p = setupLayer(l+L_LAND_32,        (mc == MC_1_0) ?
+                                           mapLand16 :
+                                           mapLandB18,     mc, 1, 2, 3,    p, 0);
         // NOTE: reusing slot for shore:16, but scale is 1:32
         p = setupLayer(l+L_SHORE_16,       mapShore,       mc, 1, 2, 1000, p, 0);
         p = setupLayer(l+L_ZOOM_16,        mapZoom,        mc, 2, 3, 1001, p, 0);

--- a/layers.c
+++ b/layers.c
@@ -2121,6 +2121,58 @@ int mapLand16(const Layer * l, int * out, int x, int z, int w, int h)
     return 0;
 }
 
+int mapLandB18(const Layer * l, int * out, int x, int z, int w, int h)
+{
+    int pX = x - 1;
+    int pZ = z - 1;
+    int pW = w + 2;
+    int pH = h + 2;
+    int i, j;
+
+    int err = l->p->getMap(l->p, out, pX, pZ, pW, pH);
+    if unlikely(err != 0)
+        return err;
+    
+    uint64_t ss = l->startSeed;
+    uint64_t cs;
+
+    for (j = 0; j < h; j++)
+    {
+        int *vz0 = out + (j+0)*pW;
+        int *vz1 = out + (j+1)*pW;
+        int *vz2 = out + (j+2)*pW;
+
+        int v00 = vz0[0], vt0 = vz0[1];
+        int v02 = vz2[0], vt2 = vz2[1];
+        int v20, v22;
+        int v11, v;
+
+        for (i = 0; i < w; i++)
+        {
+            v11 = vz1[i+1];
+            v20 = vz0[i+2];
+            v22 = vz2[i+2];
+            v = v11;
+
+            if (v11 == 0 && (v00 != 0 || v02 != 0 || v20 != 0 || v22 != 0))
+            {
+                cs = getChunkSeed(ss, i+x, j+z);
+		v = mcFirstInt(cs, 3) / 2;
+            }
+            else if (v11 == 1 && (v00 != 1 || v02 != 1 || v20 != 1 || v22 != 1))
+            {
+                cs = getChunkSeed(ss, i+x, j+z);
+                v = 1 - mcFirstInt(cs, 5) / 4;
+            }
+
+            out[i + j*w] = v;
+            v00 = vt0; vt0 = v20;
+            v02 = vt2; vt2 = v22;
+        }
+    }
+
+    return 0;
+}
 
 int mapIsland(const Layer * l, int * out, int x, int z, int w, int h)
 {

--- a/layers.h
+++ b/layers.h
@@ -529,6 +529,7 @@ mapfunc_t mapZoomFuzzy;
 mapfunc_t mapZoom;
 mapfunc_t mapLand;          // mapAddIsland
 mapfunc_t mapLand16;
+mapfunc_t mapLandB18;
 mapfunc_t mapIsland;        // mapRemoveTooMuchOcean
 mapfunc_t mapSnow;          // mapAddSnow
 mapfunc_t mapSnow16;

--- a/layers.h
+++ b/layers.h
@@ -10,7 +10,7 @@
 /* Minecraft versions */
 enum MCVersion
 {
-    MC_1_0, // <=1.0 Experimental!
+    MC_B1_8, MC_1_0, // <=1.0 Experimental!
     MC_1_1,  MC_1_2,  MC_1_3,  MC_1_4,  MC_1_5,  MC_1_6,
     MC_1_7,  MC_1_8,  MC_1_9,  MC_1_10, MC_1_11, MC_1_12,
     MC_1_13, MC_1_14, MC_1_15, MC_1_16, MC_1_17, MC_1_18,
@@ -157,6 +157,8 @@ enum LayerId
 {
     // new                  [[deprecated]]
     L_CONTINENT_4096 = 0,   L_ISLAND_4096 = L_CONTINENT_4096,
+    L_ZOOM_4096,                                                    // b1.8
+    L_LAND_4096,                                                    // b1.8
     L_ZOOM_2048,
     L_LAND_2048,            L_ADD_ISLAND_2048 = L_LAND_2048,
     L_ZOOM_1024,

--- a/util.c
+++ b/util.c
@@ -48,6 +48,7 @@ const char* mc2str(int mc)
 {
     switch (mc)
     {
+    case MC_B1_8: return "Beta 1.8"; break;
     case MC_1_0:  return "1.0"; break;
     case MC_1_1:  return "1.1"; break;
     case MC_1_2:  return "1.2"; break;
@@ -94,6 +95,7 @@ int str2mc(const char *s)
     if (!strcmp(s, "1.2")) return MC_1_2;
     if (!strcmp(s, "1.1")) return MC_1_1;
     if (!strcmp(s, "1.0")) return MC_1_0;
+    if (!strcmp(s, "Beta 1.8")) return MC_B1_8;
     return -1;
 }
 


### PR DESCRIPTION
These changes add support for Beta 1.8. 

Differences in biome generation between Beta 1.8 and Release 1.0 include:
- Beta 1.8 layer stack starts at a 1:8192 scale instead of 1:4096.
- mapLand (GenLayerAddIsland) handles RNG differently in Beta 1.8, replacing v11's biome when the high value is returned rather than the low value, giving different results even for the same seed/coords/surroundings.
- Ice plains and mushroom islands were not yet added.
- A bug in the AddIsland layer (when used once at 1:32) causes small patches of ocean to generate at the edges of plains biomes and small patches of plains to generate along coastlines.

Aside from changing getStructureConfig to show no nether fortresses in Beta 1.8, no changes have yet been made to the structure finders. Village positions are tested and correct. Mineshaft and stronghold finders are untested, will do further work in the future.