### PR TITLE
Remove premature spawn return

### DIFF
--- a/finders.c
+++ b/finders.c
@@ -791,7 +791,6 @@ Pos getSpawn(const Generator *g)
     else
     {
         spawn = findFittestPos(g);
-        return spawn;
     }
 
     SurfaceNoise sn;


### PR DESCRIPTION
After estimating the approximate spawn position, Cubiomes currently centers the position in the middle of the corresponding chunk and then (I'm guessing erroneously) returns the position immediately, completely skipping all of the code fine-tuning the position to the most likely block afterwards. As a result, every single spawnpoint calculated by Cubiomes (and consequently Cubiomes Viewer) is in the middle of a chunk, leading to problems such as origin spawns always returning as (8, 8) instead of (0, 0), and so on.