### PR TITLE
getSpawn Spiral Iterator Fix + Include Frozen Oceans in findServerSpawn Check

### DIFF
--- a/finders.c
+++ b/finders.c
@@ -664,7 +664,7 @@ static int findServerSpawn(Pos *sp, const Generator *g, const SurfaceNoise *sn,
             {
                 int x4 = (chunkX << 2) + i, z4 = (chunkZ << 2) + j;
                 int id = getBiomeAt(g, 4, x4, 16, z4);
-                if (isOceanic(id) || id == river)
+                if ((isOceanic(id) && id != frozen_ocean && id != deep_frozen_ocean) || id == river)
                     continue;
                 sp->x = x4 << 2;
                 sp->z = z4 << 2;
@@ -814,13 +814,10 @@ Pos getSpawn(const Generator *g)
         int j, k, u, v;
         j = k = u = 0;
         v = -1;
-        for (i = 0; i < 1024; i++)
+        for (i = 0; i < 121; i++)
         {
-            if (j > -16 && j <= 16 && k > -16 && k <= 16)
-            {
-                if (findServerSpawn(&spawn, g, &sn, (spawn.x>>4)+j, (spawn.z>>4)+k))
-                    return spawn;
-            }
+            if (findServerSpawn(&spawn, g, &sn, (spawn.x>>4)+j, (spawn.z>>4)+k))
+                return spawn;
 
             if (j == k || (j < 0 && j == -k) || (j > 0 && j == 1 - k))
             {


### PR DESCRIPTION
Cubitect/cubiomes-viewer#219 brought my attention to getSpawn's spiral iterator, which I checked against the actual 1.19 Java code; the actual code only runs for 121 iterations ( = a 11x11 area), not for 1024 ( = a 32x32 area), which may explain part of (though not all of) the discrepancies. The then-fixed if condition to determine whether to subsequently call findServerSpawn would also always return true as well, so I removed it.

In addition, I added frozen oceans and deep frozen oceans as valid spawn biomes in findServerSpawn; since the game itself only checks for solid non-waterlogged surface blocks, I've found in practice that one usually ends up spawning on an ice floe/iced-over ocean as opposed to the game dropping the player on the nearest mainland, which is where the Cubiomes algorithm would set the spawnpoint otherwise.