### PR TITLE
Fix undefined wrapping behavior in rng.h (Zig compatibility)

### DIFF
--- a/rng.h
+++ b/rng.h
@@ -108,7 +108,7 @@ static inline int nextInt(uint64_t *seed, const int n)
         bits = next(seed, 31);
         val = bits % n;
     }
-    while (bits - val + m < 0);
+    while (((int32_t)((uint32_t)bits - val + m) < 0));
     return val;
 }
 
@@ -261,7 +261,7 @@ static inline int xNextIntJ(Xoroshiro *xr, uint32_t n)
         bits = (xNextLong(xr) >> 33);
         val = bits % n;
     }
-    while (bits - val + m < 0);
+    while (((int32_t)((uint32_t)bits - val + m) < 0));
     return val;
 }
 

--- a/rng.h
+++ b/rng.h
@@ -108,7 +108,7 @@ static inline int nextInt(uint64_t *seed, const int n)
         bits = next(seed, 31);
         val = bits % n;
     }
-    while (((int32_t)((uint32_t)bits - val + m) < 0));
+    while ((int32_t)((uint32_t)bits - val + m) < 0);
     return val;
 }
 
@@ -261,7 +261,7 @@ static inline int xNextIntJ(Xoroshiro *xr, uint32_t n)
         bits = (xNextLong(xr) >> 33);
         val = bits % n;
     }
-    while (((int32_t)((uint32_t)bits - val + m) < 0));
+    while ((int32_t)((uint32_t)bits - val + m) < 0);
     return val;
 }
 


### PR DESCRIPTION
Takes advantage of the defined wrapping addition/subtraction behavior of unsigned integers as opposed to leaving it undefined with regular `int`s.
I don't think the casts should cost any performance if the compiler does its job but I could be wrong since I'm a bit of a low level noob.

This is important for automatically translating the header to other languages, notably Zig where behavior is strongly defined.
Most functions are translated to definitions without implementation, and linking the library provides the implementation (which can be compiled without sanitization, so cubiomes compiles and works as intended for these functions and lets things wrap if they need). But since the implementation of `nextInt` is included in the header, Zig translates it to a form which has the regular addition and subtraction operators, which has overflow checks leading to a panic in rare cases where overflow happens. The changes in this PR successfully "trick" Zig into using the wrapping versions of the addition and subtraction operators since that is the defined behavior of unsigned integers in C.