### PR TITLE
Add getStructureDimension convenience function

### DIFF
--- a/finders.c
+++ b/finders.c
@@ -55,6 +55,12 @@ uint64_t getPopulationSeed(int mc, uint64_t ws, int x, int z)
     return (x * a + z * b) ^ ws;
 }
 
+int getStructureDimension(int id)
+{
+    if (id == Ruined_Portal_N || id == Fortress || id == Bastion) return DIM_NETHER;
+    if (id == End_City || id == End_Gateway || id == End_Island) return DIM_END;
+    return DIM_OVERWORLD;
+}
 
 int getStructureConfig(int structureType, int mc, StructureConfig *sconf)
 {

--- a/finders.h
+++ b/finders.h
@@ -151,6 +151,7 @@ STRUCT(BiomeFilter)
     uint64_t biomeToPick, biomeToPickM;
 };
 
+int getStructureDimension(int id);
 
 /***************************** Structure Positions *****************************
  *


### PR DESCRIPTION
This PR adds a simple `getStructureDimension` function that is based on the id of the structure.