### PR TITLE
Fix biomes for igloos and mansions

### DIFF
--- a/biomes.h
+++ b/biomes.h
@@ -35,7 +35,8 @@ enum MCVersion
     MC_1_21_1,
     MC_1_21_3,
     MC_1_21_WD, // Winter Drop, version TBA
-    MC_1_21 = MC_1_21_WD,
+    MC_1_21_5,
+    MC_1_21 = MC_1_21_5,
     MC_NEWEST = MC_1_21,
 };
 

--- a/finders.c
+++ b/finders.c
@@ -1195,7 +1195,7 @@ int isViableFeatureBiome(int mc, int structureType, int biomeID)
 
     case Igloo:
         if (mc <= MC_1_8) return 0;
-        return biomeID == snowy_tundra || biomeID == snowy_taiga || biomeID == snowy_slopes;
+        return biomeID == snowy_taiga || biomeID == snowy_plains || biomeID == snowy_slopes;
 
     case Ocean_Ruin:
         if (mc <= MC_1_12) return 0;
@@ -1282,7 +1282,7 @@ int isViableFeatureBiome(int mc, int structureType, int biomeID)
 
     case Mansion:
         if (mc <= MC_1_10) return 0;
-        return biomeID == dark_forest || biomeID == dark_forest_hills;
+        return biomeID == dark_forest || biomeID == dark_forest_hills || biomeID == pale_garden;
 
     case Fortress:
         return (biomeID == nether_wastes || biomeID == soul_sand_valley ||

--- a/finders.c
+++ b/finders.c
@@ -1283,7 +1283,7 @@ int isViableFeatureBiome(int mc, int structureType, int biomeID)
 
     case Mansion:
         if (mc <= MC_1_10) return 0;
-        return biomeID == dark_forest || biomeID == dark_forest_hills || biomeID == pale_garden;
+        return biomeID == dark_forest || biomeID == dark_forest_hills || (mc >= MC_1_21_5 && biomeID == pale_garden);
 
     case Fortress:
         return (biomeID == nether_wastes || biomeID == soul_sand_valley ||

--- a/finders.c
+++ b/finders.c
@@ -1195,7 +1195,8 @@ int isViableFeatureBiome(int mc, int structureType, int biomeID)
 
     case Igloo:
         if (mc <= MC_1_8) return 0;
-        return biomeID == snowy_taiga || biomeID == snowy_plains || biomeID == snowy_slopes;
+        return (biomeID == snowy_tundra || biomeID == snowy_taiga
+             || biomeID == snowy_plains || biomeID == snowy_slopes);
 
     case Ocean_Ruin:
         if (mc <= MC_1_12) return 0;


### PR DESCRIPTION
When looking through `BiomeTagsProvider#addTags` I noticed that the biomes for Igloos were missing Snowy Plains, and that the newly added biome Pale Garden was missing for the Mansion structure. Note that the ID `snowy_tundra` was changed to `snowy_plains` in 21w40a.