### PR TITLE
Add cherry_grove to Stronghold biomes exclusion list

### DIFF
--- a/biomes.h
+++ b/biomes.h
@@ -35,7 +35,8 @@ enum MCVersion
     MC_1_21_1,
     MC_1_21_3,
     MC_1_21_WD, // Winter Drop, version TBA
-    MC_1_21 = MC_1_21_WD,
+    MC_1_21_9,
+    MC_1_21 = MC_1_21_9,
     MC_NEWEST = MC_1_21,
 };
 

--- a/finders.c
+++ b/finders.c
@@ -823,9 +823,11 @@ int isStrongholdBiome(int mc, int id)
     case bamboo_jungle_hills:
         // simulate MC-199298
         return mc <= MC_1_15 || mc >= MC_1_18;
+    case cherry_grove:
+        // see MC-278965
+        return mc >= MC_1_21_9;
     case mangrove_swamp:
     case deep_dark:
-    case cherry_grove:
         return 0;
     default:
         return 1;

--- a/finders.c
+++ b/finders.c
@@ -817,7 +817,7 @@ int isStrongholdBiome(int mc, int id)
         return 0;
     case mushroom_field_shore:
         return mc >= MC_1_13;
-    case stone_shore:
+    case stone_shore: // stony_shore
         return mc <= MC_1_17;
     case bamboo_jungle:
     case bamboo_jungle_hills:
@@ -825,6 +825,7 @@ int isStrongholdBiome(int mc, int id)
         return mc <= MC_1_15 || mc >= MC_1_18;
     case mangrove_swamp:
     case deep_dark:
+    case cherry_grove:
         return 0;
     default:
         return 1;


### PR DESCRIPTION
Closes #137. I also verified no other biomes were forgotten by comparing `MultiNoiseBiomeSourceParameterList.Preset.OVERWORLD.usedBiomes()` minus the exclusion list in `isStrongholdBiome` to `BiomeTags.STRONGHOLD_BIASED_TO`.

While the current implementation works, perhaps it is easier to invert the `isStrongholdBiome` function in the future. So instead of an exclusion list, make it similar to `BiomeTags.STRONGHOLD_BIASED_TO` by listing what biomes _are_ preferred.