### PR TITLE
Reverse inequality condition for mirroring of Ruined Portals

### DIFF
--- a/finders.c
+++ b/finders.c
@@ -2221,7 +2221,7 @@ int getVariant(StructureVariant *r, int structType, int mc, uint64_t seed,
             r->start = 1 + nextInt(&rng, 10);
         }
         r->rotation = nextInt(&rng, 4);
-        r->mirror = nextFloat(&rng) < 0.5f;
+        r->mirror = nextFloat(&rng) >= 0.5f;
         return 1;
 
     case Monument:


### PR DESCRIPTION
For all versions, Ruined Portals are mirrored when `nextFloat() >= 0.5`:

```java
Mirror mirror = worldgenRandom.nextFloat() < 0.5F ? Mirror.NONE : Mirror.FRONT_BACK;
```

This PR reverses the inequality in the code to respect this.