### PR TITLE
Fix structure type for s_ruined_portal_n

### DIFF
--- a/finders.c
+++ b/finders.c
@@ -80,7 +80,7 @@ int getStructureConfig(int structureType, int mc, StructureConfig *sconf)
     s_monument              = { 10387313, 32, 27, Monument,         0,0},
     s_mansion               = { 10387319, 80, 60, Mansion,          0,0},
     s_ruined_portal         = { 34222645, 40, 25, Ruined_Portal,    0,0},
-    s_ruined_portal_n       = { 34222645, 40, 25, Ruined_Portal,    DIM_NETHER,0},
+    s_ruined_portal_n       = { 34222645, 40, 25, Ruined_Portal_N,  DIM_NETHER,0},
     s_ruined_portal_n_117   = { 34222645, 25, 15, Ruined_Portal_N,  DIM_NETHER,0},
     s_ancient_city          = { 20083232, 24, 16, Ancient_City,     0,0},
     s_trail_ruins           = { 83469867, 34, 26, Trail_Ruins,      0,0},


### PR DESCRIPTION
The structure type for `s_ruined_portal_n` was wrongly `Ruined_Portal`. I have fixed it to be `Ruined_Portal_N`.